### PR TITLE
Add encrypted String attr

### DIFF
--- a/ar_doc_store.gemspec
+++ b/ar_doc_store.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activerecord" #, "~> 4.0"
   spec.add_dependency "pg", "~> 0.17"
+  spec.add_dependency "encryptor", "~> 3.0"
   # spec.add_dependency "hashie", ">=3.4.0"
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/ar_doc_store.rb
+++ b/lib/ar_doc_store.rb
@@ -18,6 +18,7 @@ module ArDocStore
     autoload :EmbedsOneAttribute, "ar_doc_store/attribute_types/embeds_one_attribute"
     autoload :EmbedsManyAttribute, "ar_doc_store/attribute_types/embeds_many_attribute"
     autoload :DatetimeAttribute, "ar_doc_store/attribute_types/datetime_attribute"
+    autoload :EncryptedStringAttribute, "ar_doc_store/attribute_types/encrypted_string_attribute"
   end
 
   @mappings = Hash.new
@@ -29,6 +30,7 @@ module ArDocStore
   @mappings[:string]      = 'ArDocStore::AttributeTypes::StringAttribute'
   @mappings[:uuid]        = 'ArDocStore::AttributeTypes::UuidAttribute'
   @mappings[:datetime]    = 'ArDocStore::AttributeTypes::DatetimeAttribute'
+  @mappings[:encrypted_string]    = 'ArDocStore::AttributeTypes::EncryptedStringAttribute'
 
   def self.mappings
     @mappings

--- a/lib/ar_doc_store/attribute_types/encrypted_string_attribute.rb
+++ b/lib/ar_doc_store/attribute_types/encrypted_string_attribute.rb
@@ -1,0 +1,43 @@
+require 'encryptor'
+
+module ArDocStore
+  module AttributeTypes
+    class EncryptedStringAttribute < BaseAttribute
+      def type
+        :encrypted_string
+      end
+
+      def self.encryption_key
+        key = ENV['AR_DOC_STORE_ENCRYPTION_KEY']
+        raise 'Encryption key nil. Please define using ENV variable AR_DOC_STORE_ENCRYPTION_KEY' if key.nil?
+        key
+      end
+
+      def self.encryption_iv
+        iv = ENV['AR_DOC_STORE_ENCRYPTION_IV']
+        raise 'Encryption iv nil. Please define using ENV variable AR_DOC_STORE_ENCRYPTION_IV' if iv.nil?
+        iv
+      end
+
+      def build
+        key = attribute.to_sym
+        model.class_eval do
+          store_accessor json_column, key
+          define_method key, -> {
+            value = read_store_attribute(json_column, key)
+            if value
+              Encryptor.decrypt(value, key: EncryptedStringAttribute.encryption_key , iv: EncryptedStringAttribute.encryption_iv) if value
+            else
+              nil
+            end
+          }
+          define_method "#{key}=".to_sym, -> (value) {
+            value = Encryptor.encrypt(value.to_s,  key: EncryptedStringAttribute.encryption_key, iv: EncryptedStringAttribute.encryption_iv) if value
+            write_store_attribute(json_column, key, value)
+          }
+          add_ransacker(key, 'text')
+        end
+      end
+    end
+  end
+end

--- a/lib/ar_doc_store/attribute_types/encrypted_string_attribute.rb
+++ b/lib/ar_doc_store/attribute_types/encrypted_string_attribute.rb
@@ -25,11 +25,7 @@ module ArDocStore
           store_accessor json_column, key
           define_method key, -> {
             value = read_store_attribute(json_column, key)
-            if value
-              Encryptor.decrypt(value, key: EncryptedStringAttribute.encryption_key , iv: EncryptedStringAttribute.encryption_iv) if value
-            else
-              nil
-            end
+            Encryptor.decrypt(value, key: EncryptedStringAttribute.encryption_key , iv: EncryptedStringAttribute.encryption_iv) if value
           }
           define_method "#{key}=".to_sym, -> (value) {
             value = Encryptor.encrypt(value.to_s,  key: EncryptedStringAttribute.encryption_key, iv: EncryptedStringAttribute.encryption_iv) if value

--- a/test/attribute_types/encrypted_string_attribute_test.rb
+++ b/test/attribute_types/encrypted_string_attribute_test.rb
@@ -1,0 +1,26 @@
+require_relative './../test_helper'
+
+class EncryptedStringAttributeTest < MiniTest::Test
+
+  def test_attribute_on_model_init
+    b = Building.new code: 'test'
+    assert_equal 'test', b.code
+  end
+
+  def test_attribute_on_existing_model
+    b = Building.new
+    b.code = 'test'
+    assert_equal 'test', b.code
+    assert b.code_changed?
+  end
+
+  def test_question_mark_method
+    b = Building.new code: 'test'
+    assert_equal true, b.code?
+  end
+
+  def test_conversion
+    b = Building.new code: 51
+    assert_equal '51', b.code
+  end
+end

--- a/test/attribute_types/encrypted_string_attribute_test.rb
+++ b/test/attribute_types/encrypted_string_attribute_test.rb
@@ -14,6 +14,13 @@ class EncryptedStringAttributeTest < MiniTest::Test
     assert b.code_changed?
   end
 
+  def test_attribute_nil_on_existing_model
+    b = Building.new
+    b.code = nil
+    assert_equal nil, b.code
+  end
+
+
   def test_question_mark_method
     b = Building.new code: 'test'
     assert_equal true, b.code?

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,9 +3,12 @@ gem 'minitest'
 
 require 'minitest/autorun'
 require 'active_record'
-
+require 'pry'
 require_relative './../lib/ar_doc_store'
 ActiveRecord::Base.establish_connection(adapter: 'postgresql', database: 'ar_doc_store_test', username: 'postgres', password: 'postgres')
+
+ENV['AR_DOC_STORE_ENCRYPTION_KEY'] ||= 'This is a key that is 256 bits!!'
+ENV['AR_DOC_STORE_ENCRYPTION_IV'] ||= 'This is a iv'
 
 # A building has many entrances and restrooms and some fields of its own
 # An entrance has a door, a route, and some fields of its own
@@ -138,6 +141,7 @@ class Building < ActiveRecord::Base
   json_attribute :multiconstruction, as: :enumeration, values: %w{concrete wood brick plaster steel}, multiple: true
   json_attribute :strict_enumeration, as: :enumeration, values: %w{happy sad glad bad}, strict: true
   json_attribute :strict_multi_enumeration, as: :enumeration, values: %w{happy sad glad bad}, multiple: true, strict: true
+  json_attribute :code, as: :encrypted_string
   embeds_many :entrances
   embeds_many :restrooms
 end


### PR DESCRIPTION
This PR adds a new type of json_attribute, :encrypted_string. When used it will be encrypt the string before writing it to the json field. When read it will decrypt it. It should make it easy for us to encrypt ids in our json data. 

It uses an env variable for the key and iv.