### PR TITLE
Fix issues

### DIFF
--- a/lib/ar_doc_store/attribute_types/embeds_one_attribute.rb
+++ b/lib/ar_doc_store/attribute_types/embeds_one_attribute.rb
@@ -28,6 +28,7 @@ module ArDocStore
             value = value.attributes
           end
           value = #{class_name}.build value
+          value.parent = self
           @#{attribute} = value
           write_store_attribute json_column, :#{attribute}, value
         end

--- a/lib/ar_doc_store/embeddable_model.rb
+++ b/lib/ar_doc_store/embeddable_model.rb
@@ -49,6 +49,7 @@ module ArDocStore
 
       def initialize_attributes(attrs)
         @attributes ||= HashWithIndifferentAccess.new
+        self.id
         self.parent = attributes.delete(:parent) if attributes
         self.attributes = attrs
       end

--- a/lib/ar_doc_store/embeddable_model.rb
+++ b/lib/ar_doc_store/embeddable_model.rb
@@ -84,16 +84,19 @@ module ArDocStore
           old_value = attributes[attribute]
           if attribute.to_s != 'id' && value != old_value
             public_send :"#{attribute}_will_change!"
-            find_parent(parent).data_will_change! if parent
+            root = find_root(parent)
+            root.data_will_change! if root
           end
 
         end
         attributes[attribute] = value
       end
 
-      def find_parent(node)
-        if node.respond_to?(:parent)
-          find_parent(node.parent)
+      def find_root(node)
+        if node.nil?
+          nil
+        elsif node.respond_to?(:parent)
+          find_root(node.parent)
         else
           node
         end

--- a/lib/ar_doc_store/embeddable_model.rb
+++ b/lib/ar_doc_store/embeddable_model.rb
@@ -84,11 +84,19 @@ module ArDocStore
           old_value = attributes[attribute]
           if attribute.to_s != 'id' && value != old_value
             public_send :"#{attribute}_will_change!"
-            parent.data_will_change! if parent
+            find_parent(parent).data_will_change! if parent
           end
 
         end
         attributes[attribute] = value
+      end
+
+      def find_parent(node)
+        if node.respond_to?(:parent)
+          find_parent(node.parent)
+        else
+          node
+        end
       end
 
       def write_default_store_attribute(attr, value)

--- a/test/originals/embedded_model_attribute_test.rb
+++ b/test/originals/embedded_model_attribute_test.rb
@@ -1,23 +1,26 @@
 require_relative './../test_helper'
 
 class EmbeddedModelAttributeTest < MiniTest::Test
-  
+
   def test_can_set_attribute_on_embedded_model_init
     b = Route.new route_surface: 'test'
     assert_equal 'test', b.route_surface
   end
-  
+
   def test_can_set_attribute_on_existing_embedded_model
     b = Route.new
     b.route_surface = 'test'
     assert_equal 'test', b.route_surface
   end
-  
+
   def test_can_set_enumeration_created_with_enumerates
     door = Door.new
     door.door_type = %w{sliding push}
     assert_equal %w{sliding push}, door.door_type
   end
 
+  def test_id_set_on_instantiation
+    door = Door.new
+    assert door.attributes[:id] != nil
+  end
 end
-

--- a/test/originals/embedding_test.rb
+++ b/test/originals/embedding_test.rb
@@ -16,7 +16,7 @@ class EmbeddingTest < MiniTest::Test
     assert_equal %w{knob}, restroom.door.open_handle
   end
 
-  def test_ensure_change_events_are_propagated_to_root_has_many_has_one
+  def test_ensure_change_events_are_propagated_to_root
     building = Building.new
     restroom = Restroom.new
     restroom.door = Door.new

--- a/test/originals/embedding_test.rb
+++ b/test/originals/embedding_test.rb
@@ -1,13 +1,13 @@
 require_relative './../test_helper'
 
 class EmbeddingTest < MiniTest::Test
-  
+
   def test_can_build_embedded_model
     restroom = Restroom.new
     door = restroom.build_door
     assert door.is_a?(Door)
   end
-  
+
   def test_ensure_door_returns_existing_door
     restroom = Restroom.new
     restroom.build_door
@@ -15,21 +15,34 @@ class EmbeddingTest < MiniTest::Test
     restroom.ensure_door
     assert_equal %w{knob}, restroom.door.open_handle
   end
-  
+
+  def test_ensure_change_events_are_propagated_to_root_has_many_has_one
+    building = Building.new
+    restroom = Restroom.new
+    restroom.door = Door.new
+    building.restrooms = [restroom]
+
+    building.clear_attribute_changes([:data])
+    assert building.changes[:data].nil?
+
+    building.restrooms.first.door.clear_space = 1
+    assert !building.changes[:data].nil?
+  end
+
   def test_attributes_equals_sets_attributes
     restroom = Restroom.new door_attributes: { clear_distance: 5, opening_force: 13, clear_space: 43 }
     assert_equal 5, restroom.door.clear_distance
     restroom.door_attributes = { _destroy: '1' }
     assert_nil restroom.door.clear_distance
   end
-  
+
   def test_attributes_equals_sets_partial_attributes
     restroom = Restroom.new door_attributes: { clear_distance: 5, opening_force: 13, clear_space: 43 }
     restroom.door_attributes = { clear_distance: 7 }
     assert_equal 7, restroom.door.clear_distance
     assert_equal 13, restroom.door.opening_force
   end
-  
+
   def test_embeds_many_attributes_equals_sets_partial_attributes
     building = Building.new
     building.restrooms << Restroom.new(door_attributes: { clear_distance: 5, opening_force: 13, clear_space: 43 })
@@ -47,7 +60,7 @@ class EmbeddingTest < MiniTest::Test
     assert_equal 1, building.restrooms.last.door.clear_distance
     assert_nil building.restrooms.detect {|restroom| restroom.id == restrooms_attributes[:a2][:id] }
   end
-  
+
   def test_attributes_method_embeds_many_does_not_clobber_existing_embeds_that_are_not_in_array
     building = Building.new
     building.restrooms << Restroom.new(door_attributes: { clear_distance: 5, opening_force: 13, clear_space: 43 })
@@ -61,7 +74,7 @@ class EmbeddingTest < MiniTest::Test
     assert_equal 10, building.restrooms.first.door.clear_distance
     assert_equal 15, building.restrooms.last.door.opening_force
   end
-  
+
   def test_attribute_validity_of_embedded_model_from_model
     b = Building.new
     r = Restroom.new


### PR DESCRIPTION
This PR fixes to issues with the behavior of ar_doc_store.


The first is it propagates changes all the way up to the root model. This way if you change a model nested a few levels below the active record model, the AR model will still know it should write itself to the DB.

The second issue it fixes is that it creates a id immediately upon instantiation of the model. It used to be lazy but this was causing us problems. When using UUID's its common practice to assign an id immediately upon instantiation.